### PR TITLE
Fixed usage typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ And then execute:
 ## Usage
 
 ```ruby
-QueryTimeout.timeout(2, ActiveRecord::Base){|connection|connection.select_all('select sleep(3)')}
+require 'mysql_query_timeout'
+
+MysqlQueryTimeout.timeout(2, ActiveRecord::Base){|connection|connection.select_all('select sleep(3)')}
 ```
 
 ## Development


### PR DESCRIPTION
There is no module called ``` QueryTimeout ```